### PR TITLE
Fix outgoing link retrieval function

### DIFF
--- a/datacore/models/entity.py
+++ b/datacore/models/entity.py
@@ -193,7 +193,7 @@ class AbstractEntityModel(models.Model):
         """Get a list of entities referenced by this object."""
         queryset = self.attributes.model.objects\
             .filter(entity=self, is_relation=True, deleted=False)
-        return queryset.value_list("destination", flat=True)
+        return list(queryset.values_list("destination", flat=True))
 
     def get_incoming_links(self, code: str = None) -> list:
         """Return a list of entities that reference this object."""


### PR DESCRIPTION
## Summary
- fix typo in `get_outgoing_links`
- ensure return type is still a list

## Testing
- `pytest -q`
- `python - <<'EOF'
print(type(list([1,2])) is list)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6847f17d83108330aef4587d550c5468