### PR TITLE
Fix list call in make_migrations

### DIFF
--- a/datacore/models/models.py
+++ b/datacore/models/models.py
@@ -221,7 +221,7 @@ class AbstractEntityClassModel(TreeNodeModel):
         - for attributes that match by code, FK is updated
         - for those that are missing in the new schema, make delete
         """
-        entities_list = list[self.entities.all()]
+        entities_list = list(self.entities.all())
         for entity in entities_list:
             all_names = added + removed + updated
             for schema in self.schemas.filter(name__in=all_names):


### PR DESCRIPTION
## Summary
- call `list()` correctly when gathering entity instances for migrations

## Testing
- `python -m py_compile datacore/models/models.py`

------
https://chatgpt.com/codex/tasks/task_e_6847f19408d08330ba2dd1e0ed136598