### PR TITLE
Fix attr cleanup call in models

### DIFF
--- a/datacore/models/models.py
+++ b/datacore/models/models.py
@@ -284,6 +284,6 @@ class AbstractEntityClassModel(TreeNodeModel):
     @classmethod
     def clean_db(cls):
         """Clean DB from deleted attributes and values."""
-        cls.attr_model.filter(deleted=True).delete()
+        cls.attr_model.objects.filter(deleted=True).delete()
 
 # The End


### PR DESCRIPTION
## Summary
- fix the cleanup helper by using the manager API on `attr_model`

## Testing
- `python -m py_compile datacore/models/models.py`

------
https://chatgpt.com/codex/tasks/task_e_6847f1a7f17083308de7f3d88fe35127