### PR TITLE
Fix leftover code in schema get_defaults

### DIFF
--- a/datacore/models/schemas.py
+++ b/datacore/models/schemas.py
@@ -151,7 +151,6 @@ containing only letters, numbers, underscores or hyphens"),
     def get_defaults(self):
         """Return defaults values."""
         return self.schema.get("default", None)
-        super().delete
 
     def delete(self):
         """Delete schema instance."""


### PR DESCRIPTION
## Summary
- remove stray `super().delete` line from `get_defaults`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847f1fd5ab88330b3c9d5ab290247e5