### PR TITLE
Handle schema fetch errors gracefully

### DIFF
--- a/datacore/tests/test_schemas.py
+++ b/datacore/tests/test_schemas.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import pytest
+from unittest.mock import patch
+import requests
+from django.core.exceptions import ValidationError
+from django.conf import settings
+import django
+
+# Configure Django once
+if not settings.configured:
+    settings.configure(
+        INSTALLED_APPS=[
+            'django.contrib.contenttypes',
+            'django.contrib.auth',
+            'django.contrib.admin',
+            'treenode',
+            'datacore',
+        ]
+    )
+    # Ensure repo root on path
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+    django.setup()
+
+from datacore.models.schemas import SchemaModel
+
+
+def test_get_schema_network_failure():
+    schema = SchemaModel(pk=1, name='test', title='Test', field_type=21)
+    schema.schema = {'$ref': 'http://example.com/schema.json'}
+    with patch('datacore.models.schemas.requests.get', side_effect=requests.RequestException('fail')):
+        with pytest.raises(ValidationError):
+            schema.get_schema()


### PR DESCRIPTION
## Summary
- handle network errors when fetching `$ref` schemas
- test schema retrieval when network request fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ab3ee90108330a4edd0412f3661c7