### PR TITLE
Fix dynamic form build

### DIFF
--- a/datacore/forms.py
+++ b/datacore/forms.py
@@ -30,34 +30,34 @@ class DynamicEntityForm(forms.ModelForm):
             )
 
         for attr in entity_class.attributes.all():
-            schema = attr.schema.get_schema()
+            schema = attr.schema.to_dict()
             field_type = schema.get("type")
-            self.fields[attr.name] = self._build_field(
-                attr.name, field_type, schema)
+            self.fields[attr.code] = self._build_field(
+                attr.code, field_type, schema)
 
     def _build_field(self, name, field_type, schema):
-        """Buld field."""
+        """Build field."""
         if field_type == "string":
             return forms.CharField(
-                label=schema.title,
+                label=schema.get("title"),
                 required=False,
                 initial=schema.get("default")
             )
         elif field_type == "integer":
             return forms.IntegerField(
-                label=schema.title,
+                label=schema.get("title"),
                 required=False,
                 initial=schema.get("default")
             )
         elif field_type == "boolean":
             return forms.BooleanField(
-                label=schema.title,
+                label=schema.get("title"),
                 required=False,
                 initial=schema.get("default")
             )
         elif field_type == "array":
             return forms.CharField(
-                label=schema.title,
+                label=schema.get("title"),
                 required=False,
                 help_text="Comma-separated list"
             )

--- a/datacore/tests/test_forms.py
+++ b/datacore/tests/test_forms.py
@@ -1,0 +1,74 @@
+from django import forms
+from django.test import SimpleTestCase
+from django.conf import settings
+import django
+
+from datacore.forms import DynamicEntityForm
+
+if not settings.configured:
+    settings.configure(
+        INSTALLED_APPS=[
+            'django.contrib.auth',
+            'django.contrib.contenttypes',
+        ],
+        DATABASES={'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': ':memory:'}},
+        USE_TZ=True,
+        SECRET_KEY='test',
+        DEFAULT_AUTO_FIELD='django.db.models.BigAutoField',
+    )
+    django.setup()
+
+
+class DummySchema:
+    def __init__(self, data):
+        self._data = data
+
+    def to_dict(self):
+        return self._data
+
+
+class DummyAttr:
+    def __init__(self, code, schema):
+        self.code = code
+        self.schema = DummySchema(schema)
+
+
+class AttrList(list):
+    def all(self):
+        return self
+
+
+class DummyEntityClass:
+    def __init__(self, attrs):
+        self.attributes = AttrList(attrs)
+
+
+from django.db import models
+
+
+class DummyModel(models.Model):
+    class Meta:
+        app_label = 'tests'
+
+
+class DummyForm(DynamicEntityForm):
+    class Meta:
+        model = DummyModel
+        fields = []
+
+
+class DynamicFormTests(SimpleTestCase):
+    def test_dynamic_fields_created_from_schema(self):
+        attrs = [
+            DummyAttr("first", {"type": "string", "title": "First"}),
+            DummyAttr("age", {"type": "integer", "title": "Age"}),
+        ]
+        entity_class = DummyEntityClass(attrs)
+        form = DummyForm(entity_class=entity_class)
+        self.assertIn("first", form.fields)
+        self.assertIsInstance(form.fields["first"], forms.CharField)
+        self.assertEqual(form.fields["first"].label, "First")
+        self.assertIn("age", form.fields)
+        self.assertIsInstance(form.fields["age"], forms.IntegerField)
+        self.assertEqual(form.fields["age"].label, "Age")
+


### PR DESCRIPTION
## Summary
- build form fields from schema dictionary
- update `_build_field` to use title and defaults from dict
- add unit tests for `DynamicEntityForm`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ab3ebd7bc83309a9857c4c945903f